### PR TITLE
Release candidate. Fixes handling of cert errors on ARRL side.

### DIFF
--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -53,7 +53,7 @@
 		{
 		    "type" : "archive",
         	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.tar.gz",
-        	    "sha256" : "c19ff722fbb9d33436d334e6cc8c7dab3cc30830a2dc205879c5c8c007882fdd"
+        	    "sha256" : "475c0fffb2e5fbea8f58469b99df802443695737ffbe02569b5fd3eebec76ff6"
 	  	}
 	    ]
 	}


### PR DESCRIPTION
Fixes tracking of cert handling errors on Logbook site. 
Command line option to wipe dupes db (for HQ staff to use when there's any issues.)