### PR TITLE
Uploads DB fixes, 1x1 calls

### DIFF
--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -52,8 +52,8 @@
 	    "sources" : [
 		{
 		    "type" : "archive",
-        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.1.tar.gz",
-        	    "sha256" : "02c9356c7fe0ea8a49b9730ca2689397bf81d924dbda9a764639ee90d2b0d78a"
+        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.2.tar.gz",
+        	    "sha256" : "4f83410944d81d3eae8128358127e34013819ddab04b0c962ebfea9433d018a2"
 	  	}
 	    ]
 	}


### PR DESCRIPTION
This release corrects behavior related to the uploads database when multiple log signing is happening at the same time, fixes 1x1 callsign handling, corrects a defect in ADIF error reporting, detects callsign certificate installation failure due to the user's computer time being far out of date, and improves accessibility for Mac users.