### PR TITLE
V2.7.3

### DIFF
--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -53,7 +53,7 @@
 		{
 		    "type" : "archive",
         	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.3.tar.gz",
-        	    "sha256" : "4c3f3492584813f402ba75422150b1e34054b6db8240d79cddfa55adf2d7441e"
+        	    "sha256" : "53821de4735deca032afb68e368458d96b154da71393812b4a67f65c7b5d455d"
 	  	}
 	    ]
 	}

--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -52,8 +52,8 @@
 	    "sources" : [
 		{
 		    "type" : "archive",
-        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.2.tar.gz",
-        	    "sha256" : "4f83410944d81d3eae8128358127e34013819ddab04b0c962ebfea9433d018a2"
+        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.3.tar.gz",
+        	    "sha256" : "4c3f3492584813f402ba75422150b1e34054b6db8240d79cddfa55adf2d7441e"
 	  	}
 	    ]
 	}


### PR DESCRIPTION
Multiple updates to stop displaying unfiltered OpenSSL errors on certificate errors.
Fix non-US portable callsigns to not use ULS for verifications
Add crypto downgrade for Apple Keyring compatible as Apple only supports obsolete cryptographic algorithms
Update metadata to fix linting errors