### PR TITLE
ULS fixes, handle network disruptions, allow renewal of expired certs

### DIFF
--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -34,8 +34,8 @@
 	    "sources" : [
 		{
 		    "type" : "archive",
-        	    "url" : "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2",
-        	    "sha256" : "dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02"
+        	    "url" : "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxWidgets-3.2.4.tar.bz2",
+        	    "sha256" : "0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e"
 	  	}
 	    ]
 	},
@@ -52,8 +52,8 @@
 	    "sources" : [
 		{
 		    "type" : "archive",
-        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.3.tar.gz",
-        	    "sha256" : "09af4fb32b633efad4e2ef9bff1ea921b41cf020cd588ea134cea317ad0176cf"
+        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.7.4.tar.gz",
+        	    "sha256" : "d9fb7226c82b804cfed927c8843515c2374fe3f34bbef02c61dc053413e84f82"
 	  	}
 	    ]
 	}


### PR DESCRIPTION
Updates to ULS handling, allow renewal of expired certs, manage network connectivity issues.