### PR TITLE
Fix Spanish localization, correct cert renewals

### DIFF
--- a/org.arrl.trustedqsl.json
+++ b/org.arrl.trustedqsl.json
@@ -52,8 +52,8 @@
 	    "sources" : [
 		{
 		    "type" : "archive",
-        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.8.3.tar.gz",
-        	    "sha256" : "652ae59936570f45fada0033da970b13fcdc0ee7d5ecf5f78e774781c2721178"
+        	    "url" : "https://www.rickmurphy.net/lotw/tqsl-2.8.4.tar.gz",
+        	    "sha256" : "6e71972ab1f6734360ff9d116f3838cf733a0ff12e2749a46084e1a14f7840fc"
 	  	}
 	    ]
 	}


### PR DESCRIPTION
The 2.8.3 release had the wrong file for the Spanish localization (Polish instead).  Fixed and build test added to correct this.
There was an issue with renewing callsign certificates where the DXCC entity did not match the implied prefix, showing up as entity '-NONE-'.  This release corrects that.